### PR TITLE
Fix #43

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -955,7 +955,7 @@ namespace uhigh.Net
                             {
                                 if (!Path.IsPathRooted(outputFile))
                                 {
-                                    outputFile = Path.Combine(projectDir, outputFile);
+                                    outputFile = Path.Combine(buildDir, outputFile);
                                 }
 
                                 success = await inMemoryCompiler.CompileToExecutable(combinedCode, outputFile, projectRootNamespace, projectClassName, project.OutputType, nugetAssemblies);
@@ -967,8 +967,8 @@ namespace uhigh.Net
                             else
                             {
                                 var defaultOutputFile = project.OutputType.Equals("Library", StringComparison.OrdinalIgnoreCase)
-                                    ? Path.Combine(projectDir, $"{project.Name}.dll")
-                                    : Path.Combine(projectDir, $"{project.Name}.exe");
+                                    ? Path.Combine(buildDir, $"{project.Name}.dll")
+                                    : Path.Combine(buildDir, $"{project.Name}.exe");
 
                                 success = await inMemoryCompiler.CompileToExecutable(combinedCode, defaultOutputFile, projectRootNamespace, projectClassName, project.OutputType, nugetAssemblies);
                                 if (success)

--- a/Compiler/InMemoryCompiler.cs
+++ b/Compiler/InMemoryCompiler.cs
@@ -639,22 +639,6 @@ namespace uhigh.Net.CodeGen
                     ? OutputKind.DynamicallyLinkedLibrary
                     : OutputKind.ConsoleApplication;
 
-                // Adjust output path extension based on output type
-                if (outputType.Equals("Library", StringComparison.OrdinalIgnoreCase))
-                {
-                    outputPath = Path.ChangeExtension(outputPath, ".dll");
-                }
-                else
-                {
-                    outputPath = Path.ChangeExtension(outputPath, ".exe");
-                }
-
-                // Create build directory
-                var buildDir = Path.Combine(Path.GetDirectoryName(outputPath)!, "build");
-                Directory.CreateDirectory(buildDir);
-
-                var finalPath = Path.Combine(buildDir, Path.GetFileName(outputPath));
-
                 var compilation = CSharpCompilation.Create(
                     Path.GetFileNameWithoutExtension(outputPath),
                     new[] { syntaxTree },
@@ -663,7 +647,7 @@ namespace uhigh.Net.CodeGen
                         outputKind,
                         mainTypeName: outputKind == OutputKind.ConsoleApplication && sourceInfo.HasMainMethod ? mainTypeName : null));
 
-                var emitResult = compilation.Emit(finalPath);
+                var emitResult = compilation.Emit(outputPath);
 
                 if (!emitResult.Success)
                 {
@@ -680,21 +664,21 @@ namespace uhigh.Net.CodeGen
                 }
 
                 // Copy required assemblies to build directory
-                await CopyRequiredAssemblies(buildDir, additionalAssemblies);
+                await CopyRequiredAssemblies(Path.GetDirectoryName(outputPath)!, additionalAssemblies);
 
                 // Create runtime configuration file only for executables
                 if (outputKind == OutputKind.ConsoleApplication)
                 {
-                    await CreateRuntimeConfigAsync(finalPath, targetFramework);
-                    Console.WriteLine($"Executable created: {finalPath}");
-                    Console.WriteLine($"Run with: dotnet \"{finalPath}\"");
+                    await CreateRuntimeConfigAsync(outputPath, targetFramework);
+                    Console.WriteLine($"Executable created: {outputPath}");
+                    Console.WriteLine($"Run with: dotnet \"{outputPath}\"");
                 }
                 else
                 {
-                    Console.WriteLine($"Library created: {finalPath}");
+                    Console.WriteLine($"Library created: {outputPath}");
                 }
 
-                Console.WriteLine($"Build directory: {buildDir}");
+                Console.WriteLine($"Build directory: {Path.GetDirectoryName(outputPath)!}");
 
                 return true;
             }

--- a/Program.cs
+++ b/Program.cs
@@ -1105,7 +1105,7 @@ public class EntryPoint
         try
         {
             var compiler = new Compiler(options.Verbose, options.StdLibPath);
-            string fileToRun;
+            string? fileToRun;
 
             // Determine what file to run
             if (string.IsNullOrEmpty(options.ProjectFile))


### PR DESCRIPTION
This fixes #43. The issue was that the compiler would take a path like `project/file.exe` and add build in the middle making it `project/build/file.exe`. But the run command gave it `project/build/file.exe` so then the compiler compiled to `project/build/build/file.exe`. This was fixed by making the compiler compile to whatever file path it is given and also making the build command add in a build folder in the path